### PR TITLE
fix(build): add linux-x64 to pnpm supportedArchitectures for CI

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -33,6 +33,7 @@ SPDX-License-Identifier = "Apache-2.0"
 path = [
   "mise.toml",
   "web/ui/.gitignore",
+  "web/ui/.npmrc",
   "web/ui/.nvmrc",
   "web/ui/embed.go.tmpl",
 ]

--- a/web/ui/.npmrc
+++ b/web/ui/.npmrc
@@ -1,0 +1,5 @@
+supportedArchitectures[os][]=linux
+supportedArchitectures[cpu][]=x64
+supportedArchitectures[os][]=darwin
+supportedArchitectures[cpu][]=arm64
+supportedArchitectures[cpu][]=x64


### PR DESCRIPTION
Add web/ui/.npmrc with supportedArchitectures so pnpm-lock.yaml includes @pnpm/exe.linux-x64 (and other linux-x64 binaries). Without this, pnpm install fails on the linux CI runner with:
  Cannot verify the identity of the @pnpm/exe.linux-x64 native binary:
  it is missing from pnpm-lock.yaml.