### PR TITLE
fix(build): pin pnpm version in Dockerfile instead of using apk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG IMAGE=golang:1.26.6-alpine3.24
 
 FROM $IMAGE AS builder
 
-RUN apk add --no-cache --no-progress ca-certificates gcc musl-dev git make nodejs npm pnpm bash
+RUN apk add --no-cache --no-progress ca-certificates gcc musl-dev git make nodejs npm bash && npm install -g pnpm@10.33.0
 
 COPY . /src
 ARG BININFO_BUILD_DATE BININFO_COMMIT_HASH BININFO_VERSION # provided to 'make install'

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -33,6 +33,7 @@ SPDX-License-Identifier = "Apache-2.0"
 path = [
   "mise.toml",
   "web/ui/.gitignore",
+  "web/ui/.npmrc",
   "web/ui/.nvmrc",
   "web/ui/embed.go.tmpl",
 ]


### PR DESCRIPTION
Alpine 3.24 ships pnpm@11.20.0 via apk, but the project uses packageManager: "pnpm@10.33.0". When pnpm 11 runs against the pnpm-10 lockfile it tries to verify @pnpm/exe.linux-x64 for pnpm 10, which is not in the lockfile, causing the build to fail:

  Cannot verify the identity of the @pnpm/exe.linux-x64 native binary:
  it is missing from pnpm-lock.yaml.

Fix: remove pnpm from apk dependencies and install the exact version matching packageManager via npm install -g pnpm@10.33.0.