### PR TITLE
fix(ui): remove format expression and tree view

### DIFF
--- a/web/ui/mantine-ui/src/pages/query/ExpressionInput.tsx
+++ b/web/ui/mantine-ui/src/pages/query/ExpressionInput.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   Group,
   InputBase,
-  Loader,
   Menu,
   Modal,
   Skeleton,
@@ -52,16 +51,14 @@ import {
 import { highlightSelectionMatches } from "@codemirror/search";
 import { lintKeymap } from "@codemirror/lint";
 import {
-  IconAlignJustified,
-  IconBinaryTree,
   IconCopy,
   IconDotsVertical,
   IconSearch,
   IconTerminal,
   IconTrash,
 } from "@tabler/icons-react";
-import { useAPIQuery } from "../../api/api";
-import { notifications } from "@mantine/notifications";
+// MAIA: "Format expression" and "Show/Hide tree view" removed — require
+// /api/v1/format_query and /api/v1/parse_query which are not available on Thanos.
 import { useSettings } from "../../state/settingsSlice";
 import MetricsExplorer from "./MetricsExplorer/MetricsExplorer";
 import ErrorBoundary from "../../components/ErrorBoundary";
@@ -76,8 +73,6 @@ interface ExpressionInputProps {
   initialExpr: string;
   metricNames: string[];
   executeQuery: (expr: string) => void;
-  treeShown: boolean;
-  setShowTree: (showTree: boolean) => void;
   duplicatePanel: (expr: string) => void;
   removePanel: () => void;
 }
@@ -88,8 +83,6 @@ const ExpressionInput: FC<ExpressionInputProps> = ({
   executeQuery,
   duplicatePanel,
   removePanel,
-  treeShown,
-  setShowTree,
 }) => {
   const theme = useComputedColorScheme();
   const { queryHistory } = useAppSelector((state) => state.queryPage);
@@ -104,38 +97,6 @@ const ExpressionInput: FC<ExpressionInputProps> = ({
   useEffect(() => {
     setExpr(initialExpr);
   }, [initialExpr]);
-
-  const {
-    data: formatResult,
-    error: formatError,
-    isFetching: isFormatting,
-    refetch: formatQuery,
-  } = useAPIQuery<string>({
-    path: "/format_query",
-    params: {
-      query: expr,
-    },
-    enabled: false,
-  });
-
-  useEffect(() => {
-    if (formatError) {
-      notifications.show({
-        color: "red",
-        title: "Error formatting query",
-        message: formatError.message,
-      });
-      return;
-    }
-
-    if (formatResult) {
-      setExpr(formatResult.data);
-      notifications.show({
-        title: "Expression formatted",
-        message: "Expression formatted successfully!",
-      });
-    }
-  }, [formatResult, formatError]);
 
   const cmRef = useRef<ReactCodeMirrorRef>(null);
 
@@ -175,9 +136,7 @@ const ExpressionInput: FC<ExpressionInputProps> = ({
     <Group align="flex-start" wrap="nowrap" gap="xs">
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
       <InputBase<any>
-        leftSection={
-          isFormatting ? <Loader size="xs" color="gray.5" /> : <IconTerminal />
-        }
+        leftSection={<IconTerminal />}
         rightSection={
           <Menu shadow="md" width={200}>
             <Menu.Target>
@@ -197,21 +156,6 @@ const ExpressionInput: FC<ExpressionInputProps> = ({
                 onClick={() => setShowMetricsExplorer(true)}
               >
                 Explore metrics
-              </Menu.Item>
-              <Menu.Item
-                leftSection={<IconAlignJustified style={menuIconStyle} />}
-                onClick={() => formatQuery()}
-                disabled={
-                  isFormatting || expr === "" || expr === formatResult?.data
-                }
-              >
-                Format expression
-              </Menu.Item>
-              <Menu.Item
-                leftSection={<IconBinaryTree style={menuIconStyle} />}
-                onClick={() => setShowTree(!treeShown)}
-              >
-                {treeShown ? "Hide" : "Show"} tree view
               </Menu.Item>
               <Menu.Item
                 leftSection={<IconCopy style={menuIconStyle} />}

--- a/web/ui/mantine-ui/src/pages/query/QueryPanel.tsx
+++ b/web/ui/mantine-ui/src/pages/query/QueryPanel.tsx
@@ -6,7 +6,6 @@ import {
   Box,
   SegmentedControl,
   Stack,
-  Skeleton,
   ActionIcon,
   Popover,
   Checkbox,
@@ -18,7 +17,7 @@ import {
   IconGraph,
   IconTable,
 } from "@tabler/icons-react";
-import { FC, Suspense, useCallback, useMemo, useState } from "react";
+import { FC, useCallback, useState } from "react";
 import { useAppDispatch, useAppSelector } from "../../state/hooks";
 import {
   addQueryToHistory,
@@ -27,7 +26,6 @@ import {
   GraphResolution,
   removePanel,
   setExpr,
-  setShowTree,
   setVisualizer,
 } from "../../state/queryPageSlice";
 import TimeInput from "./TimeInput";
@@ -36,11 +34,7 @@ import ExpressionInput from "./ExpressionInput";
 import Graph from "./Graph";
 import ResolutionInput from "./ResolutionInput";
 import TableTab from "./TableTab";
-import TreeView from "./TreeView";
-import ErrorBoundary from "../../components/ErrorBoundary";
-import ASTNode from "../../promql/ast";
-import serializeNode from "../../promql/serialize";
-// MAIA: ExplainView removed — parse_query not available on Thanos backends
+// MAIA: TreeView removed — requires /api/v1/parse_query which is not available on Thanos
 import { actionIconStyle } from "../../styles";
 
 export interface PanelProps {
@@ -60,16 +54,7 @@ const QueryPanel: FC<PanelProps> = ({ idx, metricNames }) => {
   const panel = useAppSelector((state) => state.queryPage.panels[idx]);
   const dispatch = useAppDispatch();
 
-  const [selectedNode, setSelectedNode] = useState<{
-    id: string;
-    node: ASTNode;
-  } | null>(null);
-
-  const expr = useMemo(
-    () =>
-      selectedNode !== null ? serializeNode(selectedNode.node) : panel.expr,
-    [selectedNode, panel.expr]
-  );
+  const expr = panel.expr;
 
   const onSelectRange = useCallback(
     (start: number, end: number) =>
@@ -104,13 +89,6 @@ const QueryPanel: FC<PanelProps> = ({ idx, metricNames }) => {
             dispatch(addQueryToHistory(expr));
           }
         }}
-        treeShown={panel.showTree}
-        setShowTree={(showTree: boolean) => {
-          dispatch(setShowTree({ idx, showTree }));
-          if (!showTree) {
-            setSelectedNode(null);
-          }
-        }}
         duplicatePanel={(expr: string) => {
           dispatch(duplicatePanel({ idx, expr }));
         }}
@@ -118,29 +96,6 @@ const QueryPanel: FC<PanelProps> = ({ idx, metricNames }) => {
           dispatch(removePanel(idx));
         }}
       />
-      {panel.expr.trim() !== "" && panel.showTree && (
-        <ErrorBoundary key={retriggerIdx} title="Error showing tree view">
-          <Suspense
-            fallback={
-              <Box mt="lg">
-                {Array.from(Array(20), (_, i) => (
-                  <Skeleton key={i} height={30} mb={15} width="100%" />
-                ))}
-              </Box>
-            }
-          >
-            <TreeView
-              panelIdx={idx}
-              selectedNode={selectedNode}
-              setSelectedNode={setSelectedNode}
-              closeTreeView={() => {
-                dispatch(setShowTree({ idx, showTree: false }));
-                setSelectedNode(null);
-              }}
-            />
-          </Suspense>
-        </ErrorBoundary>
-      )}
       <Tabs
         value={panel.visualizer.activeTab}
         onChange={(v) =>
@@ -332,7 +287,7 @@ const QueryPanel: FC<PanelProps> = ({ idx, metricNames }) => {
           <Space h="lg" />
           <Graph
             expr={expr}
-            node={selectedNode?.node ?? null}
+            node={null}
             endTime={panel.visualizer.endTime}
             range={panel.visualizer.range}
             resolution={panel.visualizer.resolution}

--- a/web/ui/mantine-ui/src/pages/query/urlStateEncoding.test.ts
+++ b/web/ui/mantine-ui/src/pages/query/urlStateEncoding.test.ts
@@ -74,18 +74,6 @@ describe("decodePanelOptionsFromURLParams", () => {
     expect(panels[1].expr).toBe("node_cpu_seconds_total");
   });
 
-  test("decodes show_tree parameter", () => {
-    const panelsWithTree = decodePanelOptionsFromURLParams(
-      "g0.expr=up&g0.show_tree=1"
-    );
-    expect(panelsWithTree[0].showTree).toBe(true);
-
-    const panelsWithoutTree = decodePanelOptionsFromURLParams(
-      "g0.expr=up&g0.show_tree=0"
-    );
-    expect(panelsWithoutTree[0].showTree).toBe(false);
-  });
-
   describe("tab parameter", () => {
     test("decodes numeric tab value 0 as graph", () => {
       const panels = decodePanelOptionsFromURLParams("g0.expr=up&g0.tab=0");
@@ -285,7 +273,6 @@ describe("decodePanelOptionsFromURLParams", () => {
     const panels = decodePanelOptionsFromURLParams(queryString);
     expect(panels).toHaveLength(1);
     expect(panels[0].expr).toBe("rate(http_requests_total[5m])");
-    expect(panels[0].showTree).toBe(true);
     expect(panels[0].visualizer.activeTab).toBe("graph");
     expect(panels[0].visualizer.displayMode).toBe(GraphDisplayMode.Stacked);
     expect(panels[0].visualizer.yAxisMin).toBe(0);
@@ -303,7 +290,6 @@ describe("encodePanelOptionsToURLParams", () => {
   const createPanel = (overrides: Partial<Panel> = {}): Panel => ({
     id: "test-id",
     expr: "up",
-    showTree: false,
     showMetricsExplorer: false,
     visualizer: {
       activeTab: "table",
@@ -322,7 +308,6 @@ describe("encodePanelOptionsToURLParams", () => {
     const params = encodePanelOptionsToURLParams([panel]);
 
     expect(params.get("g0.expr")).toBe("up");
-    expect(params.get("g0.show_tree")).toBe("0");
     expect(params.get("g0.tab")).toBe("table");
     expect(params.get("g0.range_input")).toBe("1h");
     expect(params.get("g0.display_mode")).toBe("lines");
@@ -336,13 +321,6 @@ describe("encodePanelOptionsToURLParams", () => {
 
     expect(params.get("g0.expr")).toBe("up");
     expect(params.get("g1.expr")).toBe("node_cpu_seconds_total");
-  });
-
-  test("encodes show_tree as 1 when true", () => {
-    const panel = createPanel({ showTree: true });
-    const params = encodePanelOptionsToURLParams([panel]);
-
-    expect(params.get("g0.show_tree")).toBe("1");
   });
 
   test("encodes different tab values", () => {
@@ -546,7 +524,6 @@ describe("encode and decode roundtrip", () => {
   const createPanel = (overrides: Partial<Panel> = {}): Panel => ({
     id: "test-id",
     expr: "up",
-    showTree: false,
     showMetricsExplorer: false,
     visualizer: {
       activeTab: "table",
@@ -563,14 +540,12 @@ describe("encode and decode roundtrip", () => {
   test("roundtrip preserves basic panel settings", () => {
     const original = createPanel({
       expr: "rate(http_requests_total[5m])",
-      showTree: true,
     });
     const encoded = encodePanelOptionsToURLParams([original]);
     const decoded = decodePanelOptionsFromURLParams(encoded.toString());
 
     expect(decoded).toHaveLength(1);
     expect(decoded[0].expr).toBe(original.expr);
-    expect(decoded[0].showTree).toBe(original.showTree);
   });
 
   test("roundtrip preserves visualizer settings", () => {
@@ -607,7 +582,7 @@ describe("encode and decode roundtrip", () => {
   test("roundtrip preserves multiple panels", () => {
     const panels = [
       createPanel({ expr: "up" }),
-      createPanel({ expr: "node_cpu_seconds_total", showTree: true }),
+      createPanel({ expr: "node_cpu_seconds_total" }),
       createPanel({
         expr: "rate(http_requests_total[5m])",
         visualizer: {
@@ -623,7 +598,6 @@ describe("encode and decode roundtrip", () => {
     expect(decoded).toHaveLength(3);
     expect(decoded[0].expr).toBe("up");
     expect(decoded[1].expr).toBe("node_cpu_seconds_total");
-    expect(decoded[1].showTree).toBe(true);
     expect(decoded[2].expr).toBe("rate(http_requests_total[5m])");
     expect(decoded[2].visualizer.displayMode).toBe(GraphDisplayMode.Heatmap);
   });

--- a/web/ui/mantine-ui/src/pages/query/urlStateEncoding.ts
+++ b/web/ui/mantine-ui/src/pages/query/urlStateEncoding.ts
@@ -35,9 +35,6 @@ export const decodePanelOptionsFromURLParams = (query: string): Panel[] => {
     decodeSetting("expr", (value) => {
       panel.expr = value;
     });
-    decodeSetting("show_tree", (value) => {
-      panel.showTree = value === "1";
-    });
     decodeSetting("tab", (value) => {
       // Numeric values are deprecated (from the old UI), but we still support decoding them.
       switch (value) {
@@ -142,7 +139,6 @@ export const encodePanelOptionsToURLParams = (
 
   panels.forEach((p, idx) => {
     addParam(idx, "expr", p.expr);
-    addParam(idx, "show_tree", p.showTree ? "1" : "0");
     addParam(idx, "tab", p.visualizer.activeTab);
     if (p.visualizer.endTime !== null) {
       addParam(idx, "end_input", formatTime(p.visualizer.endTime));

--- a/web/ui/mantine-ui/src/state/queryPageSlice.ts
+++ b/web/ui/mantine-ui/src/state/queryPageSlice.ts
@@ -65,7 +65,6 @@ export type Panel = {
   // The id is helpful as a stable key for React.
   id: string;
   expr: string;
-  showTree: boolean;
   showMetricsExplorer: boolean;
   visualizer: Visualizer;
 };
@@ -78,7 +77,6 @@ interface QueryPageState {
 export const newDefaultPanel = (): Panel => ({
   id: randomId(),
   expr: "",
-  showTree: false,
   showMetricsExplorer: false,
   visualizer: {
     activeTab: "table",
@@ -145,13 +143,6 @@ export const queryPageSlice = createSlice({
         ...state.queryHistory.filter((q) => q !== query),
       ].slice(0, 50);
     },
-    setShowTree: (
-      state,
-      { payload }: PayloadAction<{ idx: number; showTree: boolean }>
-    ) => {
-      state.panels[payload.idx].showTree = payload.showTree;
-      updateURL(state.panels);
-    },
     setVisualizer: (
       state,
       { payload }: PayloadAction<{ idx: number; visualizer: Visualizer }>
@@ -169,7 +160,6 @@ export const {
   duplicatePanel,
   setExpr,
   addQueryToHistory,
-  setShowTree,
   setVisualizer,
 } = queryPageSlice.actions;
 


### PR DESCRIPTION
## Summary

- Removes the **Format expression** menu item (called `/api/v1/format_query`) and the **Show/Hide tree view** menu item (called `/api/v1/parse_query`) from the query panel options menu.
- Both endpoints are Prometheus-native and are **not available on Thanos**, which Maia uses as its backend. This is the same reason the Explain tab was already disabled.
- Cleans up related Redux state (`showTree`), URL encoding (`show_tree` param), and test cases.

Closes https://github.wdf.sap.corp/sap-cloud-infrastructure/observability-issues/issues/1004

## Test plan

- [ ] Build passes: `cd web/ui/mantine-ui && npm run build`
- [ ] Query panel "⋮" menu shows exactly: **Explore metrics**, **Duplicate query**, **Remove query** — no format or tree items
- [ ] No TypeScript or lint errors